### PR TITLE
fix(model): specify "root" object for selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,15 @@
 ember-ebau-gwr
 ==============================================================================
 
-[Short description of the addon.]
+Development
+------------------------------------------------------------------------------
+
+```
+# start a local CORS proxy
+yarn proxy
+# start dev server
+yarn start
+```
 
 
 Compatibility

--- a/addon/models.js
+++ b/addon/models.js
@@ -2,6 +2,7 @@ import Address from "ember-ebau-gwr/models/address";
 import Client from "ember-ebau-gwr/models/client";
 import ConstructionLocalisation from "ember-ebau-gwr/models/construction-localisation";
 import ConstructionProject from "ember-ebau-gwr/models/construction-project";
+import ConstructionProjectsList from "ember-ebau-gwr/models/construction-projects-list";
 import Identification from "ember-ebau-gwr/models/identification";
 import PersonIdentification from "ember-ebau-gwr/models/person-identification";
 import RealestateIdentification from "ember-ebau-gwr/models/realestate-identification";
@@ -9,6 +10,7 @@ import SearchResult from "ember-ebau-gwr/models/search-result";
 
 export default {
   ConstructionProject,
+  ConstructionProjectsList,
   RealestateIdentification,
   Address,
   Client,

--- a/addon/models/construction-project.js
+++ b/addon/models/construction-project.js
@@ -18,7 +18,6 @@ export default class ConstructionProject extends XMLModel {
   @tracked constructionProjectDescription;
   @tracked projectFreeText1;
   @tracked projectFreeText2;
-  @tracked constructionProjectDescription;
   @tracked totalCostsOfProject;
   @tracked constructionSurveyDept;
 
@@ -42,6 +41,7 @@ export default class ConstructionProject extends XMLModel {
   constructor(...args) {
     super(...args);
     this.setFieldsFromXML({
+      root: "constructionProject",
       fields: {
         EPROID: Number,
         typeOfClient: Number,

--- a/addon/models/search-result.js
+++ b/addon/models/search-result.js
@@ -1,20 +1,17 @@
+import { tracked } from "@glimmer/tracking";
+import ConstructionProjectsList from "ember-ebau-gwr/models/construction-projects-list";
+
 import XMLModel from "./xml-model";
 
-export default class SearchResult extends Array {
-  /*
-   * You need to pass in the xmlDocument wich contains the list
-   * and specify the type of the elements via the `type` param.
-   * The `field` is the name of the list elements in the xml since
-   * this will probably not bee the model name.
-   */
-  constructor(xmlDocument, type, field) {
-    super();
-    const xmlModel = new XMLModel(xmlDocument);
-    xmlModel.setFieldsFromXML({
+export default class SearchResult extends XMLModel {
+  @tracked constructionProjectsList;
+
+  constructor(...args) {
+    super(...args);
+    this.setFieldsFromXML({
       fields: {
-        [field]: [type],
+        constructionProjectsList: [ConstructionProjectsList],
       },
     });
-    this.push(...xmlModel[field]);
   }
 }

--- a/addon/models/xml-model.js
+++ b/addon/models/xml-model.js
@@ -25,8 +25,10 @@ export default class XMLModel {
       : type(element.textContent);
   }
 
-  getFieldFromXML(path, type) {
-    const elements = this.document.querySelectorAll(path);
+  getFieldFromXML(path, type, root) {
+    const elements = this.document.querySelectorAll(
+      root ? `${root} > ${path}` : path
+    );
 
     if (elements.length) {
       return Array.isArray(type)
@@ -53,11 +55,11 @@ export default class XMLModel {
   setFieldsFromXML(xmlDefinition) {
     // We do not execute this if the model is new since there exists no xml.
     if (!this.isNew) {
-      const { fields } = xmlDefinition;
+      const { fields, root = null } = xmlDefinition;
       Object.entries(fields).forEach(([key, type]) => {
         // Do not reassign if the result is null || undefined.
         // We then want to keep the default structure.
-        this[key] = this.getFieldFromXML(key, type) ?? this[key];
+        this[key] = this.getFieldFromXML(key, type, root) ?? this[key];
       });
     }
   }

--- a/addon/services/construction-project.js
+++ b/addon/services/construction-project.js
@@ -112,10 +112,6 @@ export default class BuildingProjectService extends XMLApiService {
       return [];
     }
 
-    return new SearchResult(
-      await response.text(),
-      ConstructionProject,
-      "constructionProjectsList"
-    );
+    return new SearchResult(await response.text()).constructionProjectsList;
   }
 }

--- a/addon/templates/project/index.hbs
+++ b/addon/templates/project/index.hbs
@@ -152,11 +152,7 @@
   <h3>
     {{t "ember-gwr.components.projectForm.realEstateHeading"}}
   </h3>
-  <Field
-    type="number"
-    @required={{true}}
-    @attr="realestateIdentification.number"
-  />
+  <Field type="number" @attr="realestateIdentification.number" />
   <Field type="number" @attr="realestateIdentification.EGRID" />
 
   <h3>

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "lint:hbs": "ember-template-lint .",
     "lint:js": "eslint .",
     "start": "ember serve",
+    "proxy": "lcp --proxyUrl https://www-r.housing-stat.ch",
     "test": "npm-run-all lint:* test:*",
     "test:ember": "ember test",
     "test:ember-compatibility": "ember try:each"
@@ -70,6 +71,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.1.4",
     "loader.js": "^4.7.0",
+    "local-cors-proxy": "^1.1.0",
     "npm-run-all": "^4.1.5",
     "qunit-dom": "^1.5.0",
     "sass": "^1.29.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2473,6 +2473,11 @@ arr-union@^3.1.0:
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
   integrity sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=
 
+array-back@^3.0.1:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/array-back/-/array-back-3.1.0.tgz#b8859d7a508871c9a7b2cf42f99428f65e96bfb0"
+  integrity sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==
+
 array-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
@@ -4872,6 +4877,16 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
+command-line-args@^5.0.2:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/command-line-args/-/command-line-args-5.1.1.tgz#88e793e5bb3ceb30754a86863f0401ac92fd369a"
+  integrity sha512-hL/eG8lrll1Qy1ezvkant+trihbGnaKaeEjj6Scyr3DN+RC7iQ5Rz84IeLERfAWDGo0HBSNAakczwgCilDXnWg==
+  dependencies:
+    array-back "^3.0.1"
+    find-replace "^3.0.0"
+    lodash.camelcase "^4.3.0"
+    typical "^4.0.0"
+
 commander@2.8.x:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.8.1.tgz#06be367febfda0c330aa1e2a072d3dc9762425d4"
@@ -5191,6 +5206,14 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
+
+cors@^2.8.4:
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
+  integrity sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==
+  dependencies:
+    object-assign "^4"
+    vary "^1"
 
 cosmiconfig@^6.0.0:
   version "6.0.0"
@@ -7290,7 +7313,7 @@ expand-tilde@^2.0.0, expand-tilde@^2.0.2:
   dependencies:
     homedir-polyfill "^1.0.1"
 
-express@^4.10.7, express@^4.17.1:
+express@^4.10.7, express@^4.16.3, express@^4.17.1:
   version "4.17.1"
   resolved "https://registry.yarnpkg.com/express/-/express-4.17.1.tgz#4491fc38605cf51f8629d39c2b5d026f98a4c134"
   integrity sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==
@@ -7586,6 +7609,13 @@ find-npm-prefix@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/find-npm-prefix/-/find-npm-prefix-1.0.2.tgz#8d8ce2c78b3b4b9e66c8acc6a37c231eb841cfdf"
   integrity sha512-KEftzJ+H90x6pcKtdXZEPsQse8/y/UnvzRKrOSQFprnrGaFuJ62fVkP34Iu2IYuMvyauCyoLTNkJZgrrGA2wkA==
+
+find-replace@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/find-replace/-/find-replace-3.0.0.tgz#3e7e23d3b05167a76f770c9fbd5258b0def68c38"
+  integrity sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==
+  dependencies:
+    array-back "^3.0.1"
 
 find-up@^2.0.0, find-up@^2.1.0:
   version "2.1.0"
@@ -9900,6 +9930,17 @@ loader.js@^4.7.0:
   resolved "https://registry.yarnpkg.com/loader.js/-/loader.js-4.7.0.tgz#a1a52902001c83631efde9688b8ab3799325ef1f"
   integrity sha512-9M2KvGT6duzGMgkOcTkWb+PR/Q2Oe54df/tLgHGVmFpAmtqJ553xJh6N63iFYI2yjo2PeJXbS5skHi/QpJq4vA==
 
+local-cors-proxy@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/local-cors-proxy/-/local-cors-proxy-1.1.0.tgz#570a0abb19ba102ddccd3113e92fbf44cb075756"
+  integrity sha512-1UVrdG10HAT58TNZBhYSeMPkwQANuJunFsWBgEYOd1RChLDHGhvNPjUT8JsOlcqoJyr0QOH9cLx9IOLATf4j5w==
+  dependencies:
+    chalk "^2.3.2"
+    command-line-args "^5.0.2"
+    cors "^2.8.4"
+    express "^4.16.3"
+    request "^2.85.0"
+
 locale-emoji@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/locale-emoji/-/locale-emoji-0.3.0.tgz#7f38262f7c877bd27659725570335b263f88742a"
@@ -10032,6 +10073,11 @@ lodash.assignin@^4.1.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.assignin/-/lodash.assignin-4.2.0.tgz#ba8df5fb841eb0a3e8044232b0e263a8dc6a28a2"
   integrity sha1-uo31+4QesKPoBEIysOJjqNxqKKI=
+
+lodash.camelcase@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
+  integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
 
 lodash.capitalize@^4.2.1:
   version "4.2.1"
@@ -11285,7 +11331,7 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-object-assign@4.1.1, object-assign@^4.1.0, object-assign@^4.1.1:
+object-assign@4.1.1, object-assign@^4, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
@@ -12681,7 +12727,7 @@ request-promise-native@^1.0.5, request-promise-native@^1.0.8:
     stealthy-require "^1.1.1"
     tough-cookie "^2.3.3"
 
-request@^2.88.0, request@^2.88.2:
+request@^2.85.0, request@^2.88.0, request@^2.88.2:
   version "2.88.2"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
   integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
@@ -14383,6 +14429,11 @@ typescript-memoize@^1.0.0-alpha.3:
   resolved "https://registry.yarnpkg.com/typescript-memoize/-/typescript-memoize-1.0.0-alpha.4.tgz#fd97ab63807c3392af5d0ac5f4754254a4fcd634"
   integrity sha512-woA2UUWSvx8ugkEjPN8DMuNjukBp8NQeLmz+LRXbEsQIvhLR8LSlD+8Qxdk7NmgE8xeJabJdU8zSrO4ozijGjg==
 
+typical@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/typical/-/typical-4.0.0.tgz#cbeaff3b9d7ae1e2bbfaf5a4e6f11eccfde94fc4"
+  integrity sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==
+
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
@@ -14668,7 +14719,7 @@ validate-npm-package-name@^3.0.0, validate-npm-package-name@~3.0.0:
   dependencies:
     builtins "^1.0.3"
 
-vary@~1.1.2:
+vary@^1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=


### PR DESCRIPTION
Some XML elements can appear multiple times in the DOM, e.g. realestateIdentification can be part of a constructionProject or of a building. By specifying the root (direct parent) we don't accidentally query properties of children.

Depends on #10 