### PR TITLE
fix(select): convert the values to number for selects since otherwise the active option is broken

### DIFF
--- a/addon/components/project-form/field.hbs
+++ b/addon/components/project-form/field.hbs
@@ -20,6 +20,7 @@
         @noPlaceholder={{@noPlaceholder}}
         @update={{fn (or @update this.updateProjectField) @attr}}
         @translationBase={{@translationBase}}
+        @convertValueTo={{@convertValueTo}}
         disabled={{this.disableInput}}
         readonly={{this.disableInput}}
         ...attributes

--- a/addon/components/project-form/field.js
+++ b/addon/components/project-form/field.js
@@ -2,6 +2,12 @@ import { get, set, action } from "@ember/object";
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 
+export const converstionTypeMapping = {
+  number: Number,
+  string: String,
+  boolean: Boolean,
+};
+
 export default class ProjectFormFieldComponent extends Component {
   @tracked diffResolved = false;
 
@@ -24,7 +30,12 @@ export default class ProjectFormFieldComponent extends Component {
 
   @action
   updateProjectField(attr, eventOrValue) {
-    const value = eventOrValue?.target?.value ?? eventOrValue;
+    let value = eventOrValue?.target?.value ?? eventOrValue;
+
+    if (this.args.convertValueTo) {
+      value =
+        converstionTypeMapping[this.args.convertValueTo]?.(value) ?? value;
+    }
 
     // If we supply a custom update method use this
     if (this.args.update) {

--- a/addon/components/project-form/input.js
+++ b/addon/components/project-form/input.js
@@ -1,9 +1,0 @@
-import { action } from "@ember/object";
-import Component from "@glimmer/component";
-
-export default class ProjectFormInputComponent extends Component {
-  @action
-  updateValue(event) {
-    this.args.update(event.target.value);
-  }
-}

--- a/addon/components/project-form/select.js
+++ b/addon/components/project-form/select.js
@@ -1,9 +1,0 @@
-import { action } from "@ember/object";
-import Component from "@glimmer/component";
-
-export default class ProjectFormSelectComponent extends Component {
-  @action
-  updateValue(event) {
-    this.args.update(event.target.value);
-  }
-}

--- a/addon/components/project-form/textarea.js
+++ b/addon/components/project-form/textarea.js
@@ -1,9 +1,0 @@
-import { action } from "@ember/object";
-import Component from "@glimmer/component";
-
-export default class ProjectFormTextareaComponent extends Component {
-  @action
-  updateValue(event) {
-    this.args.update(event.target.value);
-  }
-}

--- a/addon/templates/project/form.hbs
+++ b/addon/templates/project/form.hbs
@@ -90,6 +90,7 @@
 
       <Field
         @inputType="select"
+        @convertValueTo="number"
         @required={{true}}
         @attr="typeOfConstructionProject"
         @options={{this.choiceOptions.typeOfConstructionProjectOptions}}
@@ -105,6 +106,7 @@
 
       <Field
         @inputType="select"
+        @convertValueTo="number"
         @required={{true}}
         @attr="typeOfPermit"
         @options={{this.choiceOptions.typeOfPermitOptions}}
@@ -120,6 +122,7 @@
 
       <Field
         @inputType="select"
+        @convertValueTo="number"
         @attr="typeOfConstruction"
         @options={{this.choiceOptions.typeOfConstructionOptions}}
       />
@@ -182,6 +185,7 @@
 
       <Field
         @inputType="select"
+        @convertValueTo="number"
         @required={{true}}
         @attr="typeOfClient"
         @options={{this.choiceOptions.typeOfClientOptions}}


### PR DESCRIPTION
The `{{eq @value currentOption}}` would break if `@value` is a string since `eq` works by strict comparison.
Now you can specify a optional argument which then converts the value to the specified type.

Also remove unneeded component files since the update method for those components is handled in `project-form/field.js`.