### PR TITLE
fix(auth): reenable configuration for user and password in the config service

### DIFF
--- a/addon/services/auth-fetch.js
+++ b/addon/services/auth-fetch.js
@@ -17,6 +17,10 @@ export default class AuthFetchService extends Service {
   @lastValue("housingStatToken") token;
   @task
   *housingStatToken(username, password) {
+    if (this.config.username && this.config.password) {
+      ({ username, password } = this.config);
+    }
+
     const response = yield fetch(`/api/v1/housing-stat-token`, {
       method: "post",
       headers: {


### PR DESCRIPTION
The properties `username` and `password` can now be set again in the passed config service.
This is needed as long as we dont have access to the current `municipalityId` and
`constructionSurveyDepNumber` for the logged in user from the gwr API.
