### PR TITLE
fix(login): hide login modal after authentication

### DIFF
--- a/addon/controllers/application.js
+++ b/addon/controllers/application.js
@@ -1,0 +1,6 @@
+import Controller from "@ember/controller";
+import { inject as service } from "@ember/service";
+
+export default class ApplicationController extends Controller {
+  @service authFetch;
+}

--- a/addon/routes/application.js
+++ b/addon/routes/application.js
@@ -1,0 +1,3 @@
+import Route from "@ember/routing/route";
+
+export default class ApplicationRoute extends Route {}

--- a/addon/templates/application.hbs
+++ b/addon/templates/application.hbs
@@ -1,6 +1,8 @@
 <section class="uk-flex uk-flex-column uk-height-1 ebau-gwr">
-  <div id="ember-ebau-gwr-modal-container">
-  </div>
+  <div
+    id="ember-ebau-gwr-modal-container"
+    class="{{unless this.authFetch.showAuthModal "uk-invisible"}}"
+  ></div>
   <LoginModal @model={{@model}}>
     {{outlet}}
   </LoginModal>

--- a/tests/unit/controllers/application-test.js
+++ b/tests/unit/controllers/application-test.js
@@ -1,0 +1,15 @@
+import engineResolverFor from "ember-engines/test-support/engine-resolver-for";
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+
+const modulePrefix = "ember-ebau-gwr";
+const resolver = engineResolverFor(modulePrefix);
+module("Unit | Controller | application", function (hooks) {
+  setupTest(hooks, { resolver, integration: true });
+
+  // TODO: Replace this with your real tests.
+  test("it exists", function (assert) {
+    const controller = this.owner.lookup("controller:application");
+    assert.ok(controller);
+  });
+});

--- a/tests/unit/routes/application-test.js
+++ b/tests/unit/routes/application-test.js
@@ -1,0 +1,14 @@
+import engineResolverFor from "ember-engines/test-support/engine-resolver-for";
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+
+const modulePrefix = "ember-ebau-gwr";
+const resolver = engineResolverFor(modulePrefix);
+module("Unit | Route | application", function (hooks) {
+  setupTest(hooks, { resolver, integration: true });
+
+  test("it exists", function (assert) {
+    const route = this.owner.lookup("route:application");
+    assert.ok(route);
+  });
+});


### PR DESCRIPTION
Make login modal invisible after successful login to ensure
that the underlying ui is interactable.

Related to: #62 