### PR TITLE
fix(modal): show and contain gwr modal

### DIFF
--- a/addon/components/link-building-modal.hbs
+++ b/addon/components/link-building-modal.hbs
@@ -8,7 +8,7 @@
       {{t "ember-gwr.components.linkBuildingModal.linkBuilding"}}
     </h2>
   </Modal.header>
-  <Modal.body>
+  <Modal.body {{toggle-modal @visible}}>
     {{#let
       (component
         "project-form/field"

--- a/addon/components/login-modal.hbs
+++ b/addon/components/login-modal.hbs
@@ -10,7 +10,7 @@
       {{t "ember-gwr.components.loginModal.header"}}
     </h2>
   </Modal.header>
-  <Modal.body>
+  <Modal.body {{toggle-modal this.authFetch.showAuthModal}}>
     <div class="uk-grid-small" uk-grid>
       <div class="uk-width-1-2">
         <input

--- a/addon/modifiers/toggle-modal.js
+++ b/addon/modifiers/toggle-modal.js
@@ -1,0 +1,13 @@
+import { modifier } from "ember-modifier";
+
+export default modifier(function toggleModal(
+  element,
+  [visible = false] = [] /*, hash*/
+) {
+  const modalContainerClasses = document.getElementById(
+    "ember-ebau-gwr-modal-container"
+  ).classList;
+  return visible
+    ? modalContainerClasses.remove("uk-invisible")
+    : modalContainerClasses.add("uk-invisible");
+});

--- a/app/styles/ember-ebau-gwr.scss
+++ b/app/styles/ember-ebau-gwr.scss
@@ -1,15 +1,32 @@
 @import "ember-uikit";
 
 .ebau-gwr {
+  position: relative;
+
   #ember-ebau-gwr-modal-container {
     position: absolute;
-    width: 100%;
-    height: 100%;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
 
     div.uk-modal {
       position: relative;
-      width: 100%;
-      height: 100%;
+      min-height: calc(100% - 2 * #{$modal-padding-vertical});
+      min-width: calc(100% - 2 * #{$modal-padding-horizontal});
+    }
+
+    @media (min-width: $breakpoint-small) {
+      div.uk-modal {
+        min-height: calc(100% - 2 * #{$modal-padding-vertical-s});
+        min-width: calc(100% - 2 * #{$modal-padding-horizontal-s});
+      }
+    }
+
+    @media (min-width: $breakpoint-medium) {
+      div.uk-modal {
+        min-width: calc(100% - 2 * #{$modal-padding-horizontal-m});
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "ember-export-application-global": "^2.0.1",
     "ember-load-initializers": "^2.1.2",
     "ember-maybe-import-regenerator": "^0.1.6",
+    "ember-modifier": "^2.1.2",
     "ember-page-title": "^6.2.1",
     "ember-qunit": "^5.1.2",
     "ember-resolver": "^8.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7072,6 +7072,16 @@ ember-compatibility-helpers@^1.1.1, ember-compatibility-helpers@^1.1.2, ember-co
     ember-cli-version-checker "^5.1.1"
     semver "^5.4.1"
 
+ember-compatibility-helpers@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.4.tgz#70e0fef7048969141626eed6006f3880df612cd1"
+  integrity sha512-qjzQVtogyYJrSs6I4DuyCDwDCaj5JWBVNPoZDZBk8pt7caNoN0eBYRYJdin95QKaNMQODxTLPWaI4UUDQ1YWhg==
+  dependencies:
+    babel-plugin-debug-macros "^0.2.0"
+    ember-cli-version-checker "^5.1.1"
+    fs-extra "^9.1.0"
+    semver "^5.4.1"
+
 ember-composable-helpers@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/ember-composable-helpers/-/ember-composable-helpers-4.5.0.tgz#94febbdf4348e64f45f7a6f993f326e32540a61e"
@@ -7292,6 +7302,19 @@ ember-modifier@^2.1.0:
     ember-cli-normalize-entity-name "^1.0.0"
     ember-cli-string-utils "^1.1.0"
     ember-cli-typescript "^3.1.3"
+    ember-destroyable-polyfill "^2.0.2"
+    ember-modifier-manager-polyfill "^1.2.0"
+
+ember-modifier@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/ember-modifier/-/ember-modifier-2.1.2.tgz#62d18faedf972dcd9d34f90d5321fbc943d139b1"
+  integrity sha512-3Lsu1fV1sIGa66HOW07RZc6EHISwKt5VA5AUnFss2HX6OTfpxTJ2qvPctt2Yt0XPQXJ4G6BQasr/F35CX7UGJA==
+  dependencies:
+    ember-cli-babel "^7.22.1"
+    ember-cli-normalize-entity-name "^1.0.0"
+    ember-cli-string-utils "^1.1.0"
+    ember-cli-typescript "^3.1.3"
+    ember-compatibility-helpers "^1.2.4"
     ember-destroyable-polyfill "^2.0.2"
     ember-modifier-manager-polyfill "^1.2.0"
 
@@ -8806,7 +8829,7 @@ fs-extra@^8.0.0, fs-extra@^8.0.1, fs-extra@^8.1.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^9.0.0, fs-extra@^9.0.1:
+fs-extra@^9.0.0, fs-extra@^9.0.1, fs-extra@^9.1.0:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
   integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==


### PR DESCRIPTION
Fix focus-trap issues with modal visibility and contain
application modal container and its contents to gwr
application.

Note: Necessitates adding `@import "ember-ebau-gwr";` to `camac-ng/ember-camac-ng/app/styles/app.scss` for changes to take effect.

Link building:  
![image](https://user-images.githubusercontent.com/32454507/123668231-35126480-d83b-11eb-941d-ef684db419e7.png)

Login:  
![image](https://user-images.githubusercontent.com/32454507/123669238-2a0c0400-d83c-11eb-9e53-2503412761be.png)
