### PR TITLE
fix: don't import full uikit

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,15 @@ will then be used to filter the `gwr-links` by their attribute `local_id`.
 this.mount("ember-ebau-gwr", { as: "gwr", path: "gwr/:id" });
 ```
 
+### Styling
+
+The engine uses the UI framework "UIkit" through [ember-uikit](https://github.com/adfinis-sygroup/ember-uikit). To enable the styling, add the following import to `app/styles/app.scss`:
+
+```scss
+@import "ember-uikit";
+@import "ember-ebau-gwr";
+```
+
 ### Services
 
 The engine takes following services as argument:

--- a/app/styles/ember-ebau-gwr.scss
+++ b/app/styles/ember-ebau-gwr.scss
@@ -1,4 +1,4 @@
-@import "ember-uikit";
+@import "ember-uikit/variables-theme";
 @import "validated-form";
 
 .ebau-gwr {


### PR DESCRIPTION
The full uikit import should always be in the host app, otherwise uikit
will be added multiple times to the compiled css.