### PR TITLE
fix(model-form): fix resetting date input after manual entry

### DIFF
--- a/addon/components/model-form/date.hbs
+++ b/addon/components/model-form/date.hbs
@@ -6,7 +6,7 @@
     @format="DD.MM.YYYY"
     @placeholder={{t "ember-gwr.components.modelForm.datePlaceholder"}}
     @onSelection={{@update}}
-    @value={{@value}}
+    @value={{this.value}}
     @disabled={{@disabled}}
     class="uk-width-1 uk-input
       {{if @isInvalid "uk-form-danger"}}

--- a/addon/components/model-form/date.js
+++ b/addon/components/model-form/date.js
@@ -1,0 +1,13 @@
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+
+// TODO: remove file once two-way binding issue of value is resolved in ember-pikaday
+// https://github.com/adopted-ember-addons/ember-pikaday/issues/212
+export default class ModelFormDateComponent extends Component {
+  @tracked value;
+
+  constructor(...args) {
+    super(...args);
+    this.value = this.args.value;
+  }
+}


### PR DESCRIPTION
Fix date input bug where the input can no longer be picked
after manually entering a value in the input field.

Resolves #98 