### PR TITLE
fix(project): make typeOfConstruction field of project required

### DIFF
--- a/addon/templates/project/form.hbs
+++ b/addon/templates/project/form.hbs
@@ -92,6 +92,7 @@
         @convertValueTo="number"
         @attr="typeOfConstruction"
         @gwrEnumOptions={{this.choiceOptions.typeOfConstructionOptions}}
+        @required={{true}}
       />
       <h3>
         {{t "ember-gwr.components.projectForm.dates"}}

--- a/addon/validations/construction-project.js
+++ b/addon/validations/construction-project.js
@@ -20,6 +20,7 @@ export default {
     validateNumber({ lte: 99999999900 }),
     validateNumber({ integer: true }),
   ],
+  typeOfConstruction: [validatePresence(true)],
   projectAnnouncementDate: [validatePresence(true)],
   typeOfClient: [validatePresence(true)],
   client: {


### PR DESCRIPTION
Backend requires the typeOfConstruction field to be set on
a project. The field's presence is checked through the
corresponding model-form validation.

Resolves #101 