### PR TITLE
fix(project): allow unrounded values for totalCostsOfProject field

### DIFF
--- a/addon/templates/project/form.hbs
+++ b/addon/templates/project/form.hbs
@@ -81,9 +81,6 @@
       />
       <Field
         @type="number"
-        @step="1000"
-        @min="1000"
-        @max="99999999900"
         @required={{true}}
         @attr="totalCostsOfProject"
       />


### PR DESCRIPTION
Allow any integer value within the min/max requirements to
be entered in the totalCostsOfProject field. The backend
accepts the value and rounds it to the nearest 1000.

Resolves #100 