### PR TITLE
style(header): change error alert in header to warning

### DIFF
--- a/addon/components/model-form/header/errors.hbs
+++ b/addon/components/model-form/header/errors.hbs
@@ -1,12 +1,12 @@
 {{#unless @model.isNew}}
   <div
     uk-alert
-    class="{{if this.errorCount "uk-alert-danger" "uk-alert-success"}}
+    class="{{if this.errorCount "uk-alert-warning" "uk-alert-success"}}
       uk-margin-remove-top uk-margin-small-bottom uk-padding-small uk-flex-inline uk-flex-middle"
   >
     <div
       class="uk-label
-        {{if this.errorCount "uk-label-danger" "uk-label-success"}}"
+        {{if this.errorCount "uk-label-warning" "uk-label-success"}}"
     >
       {{this.errorCount}}
     </div>


### PR DESCRIPTION
Make error alert message in header appear less critical.

![image](https://user-images.githubusercontent.com/32454507/129331390-c613d9e4-bcd3-4346-a238-439f7f0c2469.png)
