### PR TITLE
fix(project): fix date fields in project form

### DIFF
--- a/addon/components/model-form/header/status-selector/submit-parameters.hbs
+++ b/addon/components/model-form/header/status-selector/submit-parameters.hbs
@@ -37,6 +37,7 @@
               @type={{parameter.type}}
               @name={{parameter.field}}
               @required={{parameter.required}}
+              @hint={{if parameter.hint (t parameter.hint)}}
               @renderComponent={{if
                 (eq parameter.type "date")
                 (component "model-form/date")

--- a/addon/controllers/building/edit/dwelling/edit.js
+++ b/addon/controllers/building/edit/dwelling/edit.js
@@ -86,6 +86,7 @@ export default class BuildingEditDwellingEditController extends Controller {
           );
         }
       }
+      this.errors = [];
       this.notification.success(this.intl.t("ember-gwr.dwelling.saveSuccess"));
     } catch (error) {
       this.errors = error;

--- a/addon/controllers/building/edit/entrance/edit/index.js
+++ b/addon/controllers/building/edit/entrance/edit/index.js
@@ -57,6 +57,7 @@ export default class BuildingEditEntranceEditIndexController extends Controller 
           this.model.buildingId
         );
       }
+      this.errors = [];
       this.notification.success(
         this.intl.t("ember-gwr.buildingEntrance.saveSuccess")
       );

--- a/addon/controllers/building/edit/form.js
+++ b/addon/controllers/building/edit/form.js
@@ -97,6 +97,7 @@ export default class BuildingFormController extends Controller {
       // Clear cache so after transition we fetch the project form api
       this.constructionProject.clearCache(this.model.projectId);
       this.buildingAPI.clearCache(this.model.buildingId);
+      this.errors = [];
       this.transitionToRoute("building.edit.form", EGID);
       this.notification.success(this.intl.t("ember-gwr.building.saveSuccess"));
     } catch (error) {

--- a/addon/controllers/project/form.js
+++ b/addon/controllers/project/form.js
@@ -75,6 +75,7 @@ export default class ProjectFormController extends Controller {
         yield this.constructionProject.update(this.project);
       }
       this.import = false;
+      this.errors = [];
       this.notification.success(
         this.intl.t("ember-gwr.constructionProject.saveSuccess")
       );

--- a/addon/models/construction-project.js
+++ b/addon/models/construction-project.js
@@ -124,40 +124,20 @@ export default class ConstructionProject extends XMLModel {
     <ns2:totalCostsOfProject>{{model.totalCostsOfProject}}</ns2:totalCostsOfProject>
     <ns2:projectAnnouncementDate>{{echDate model.projectAnnouncementDate}}</ns2:projectAnnouncementDate>
 
-    {{#if model.buildingPermitIssueDate}}
-      <ns2:buildingPermitIssueDate>{{echDate model.buildingPermitIssueDate}}</ns2:buildingPermitIssueDate>
-    {{/if}}
+    {{{modelField model "buildingPermitIssueDate" value=(echDate model.buildingPermitIssueDate)}}}
 
     {{#unless model.isNew}}
-      {{#if model.projectStartDate}}
-        <ns2:projectStartDate>{{echDate model.projectStartDate}}</ns2:projectStartDate>
-      {{/if}}
+      {{{modelField model "projectStartDate" value=(echDate model.projectStartDate)}}}
+      {{{modelField model "projectCompletionDate" value=(echDate model.projectCompletionDate)}}}
 
-      {{#if model.projectCompletionDate}}
-        <ns2:projectCompletionDate>{{echDate model.projectCompletionDate}}</ns2:projectCompletionDate>
-      {{/if}}
-      
       {{! These fields are accepted by the api but it seems like theire not actually written.}}
-      {{#if model.projectSuspensionDate}}
-        <ns2:projectSuspensionDate>{{echDate model.projectSuspensionDate}}</ns2:projectSuspensionDate>
-      {{/if}}
+      {{{modelField model "projectSuspensionDate" value=(echDate model.projectSuspensionDate)}}}
+      {{{modelField model "constructionAuthorisationDeniedDate" value=(echDate model.constructionAuthorisationDeniedDate)}}}
       
-      {{#if model.constructionAuthorisationDeniedDate}}
-        <ns2:constructionAuthorisationDeniedDate>{{echDate model.constructionAuthorisationDeniedDate}}</ns2:constructionAuthorisationDeniedDate>
-      {{/if}}
-    
       {{! this is accepted by the api but in the response the field is missing. Is this intended?}}
-      {{#if model.nonRealisationDate}}
-        <ns2:cancellationDate>{{echDate model.nonRealisationDate}}</ns2:cancellationDate>
-      {{/if}}
-
-      {{#if model.withdrawalDate}}
-        <ns2:withdrawalDate>{{echDate model.withdrawalDate}}</ns2:withdrawalDate>
-      {{/if}}
-
-      {{#if model.durationOfConstructionPhase}}
-        <ns2:durationOfConstructionPhase>{{model.durationOfConstructionPhase}}</ns2:durationOfConstructionPhase>
-      {{/if}}
+      {{{modelField model "withdrawalDate" value=(echDate model.withdrawalDate)}}}
+      {{{modelField model "cancellationDate" value=(echDate model.nonRealisationDate)}}}
+      {{{modelField model "durationOfConstructionPhase"}}}
     {{/unless}}
 
     {{#if model.isNew}}

--- a/addon/models/construction-project.js
+++ b/addon/models/construction-project.js
@@ -127,32 +127,38 @@ export default class ConstructionProject extends XMLModel {
     {{#if model.buildingPermitIssueDate}}
       <ns2:buildingPermitIssueDate>{{echDate model.buildingPermitIssueDate}}</ns2:buildingPermitIssueDate>
     {{/if}}
-    {{#if model.projectStartDate}}
-      <ns2:projectStartDate>{{echDate model.projectStartDate}}</ns2:projectStartDate>
-    {{/if}}
 
-    {{#if model.projectCompletionDate}}
-      <ns2:projectCompletionDate>{{echDate model.projectCompletionDate}}</ns2:projectCompletionDate>
-    {{/if}}
+    {{#unless model.isNew}}
+      {{#if model.projectStartDate}}
+        <ns2:projectStartDate>{{echDate model.projectStartDate}}</ns2:projectStartDate>
+      {{/if}}
 
-    {{#if model.durationOfConstructionPhase}}
-      <ns2:durationOfConstructionPhase>{{model.durationOfConstructionPhase}}</ns2:durationOfConstructionPhase>
-    {{/if}}
+      {{#if model.projectCompletionDate}}
+        <ns2:projectCompletionDate>{{echDate model.projectCompletionDate}}</ns2:projectCompletionDate>
+      {{/if}}
+      
+      {{! These fields are accepted by the api but it seems like theire not actually written.}}
+      {{#if model.projectSuspensionDate}}
+        <ns2:projectSuspensionDate>{{echDate model.projectSuspensionDate}}</ns2:projectSuspensionDate>
+      {{/if}}
+      
+      {{#if model.constructionAuthorisationDeniedDate}}
+        <ns2:constructionAuthorisationDeniedDate>{{echDate model.constructionAuthorisationDeniedDate}}</ns2:constructionAuthorisationDeniedDate>
+      {{/if}}
+    
+      {{! this is accepted by the api but in the response the field is missing. Is this intended?}}
+      {{#if model.nonRealisationDate}}
+        <ns2:cancellationDate>{{echDate model.nonRealisationDate}}</ns2:cancellationDate>
+      {{/if}}
 
-    {{! These fields are accepted by the api but it seems like theire not actually written.}}
-    {{#if model.projectSuspensionDate}}
-      <ns2:projectSuspensionDate>{{echDate model.projectSuspensionDate}}</ns2:projectSuspensionDate>
-    {{/if}}
-    {{#if model.constructionAuthorisationDeniedDate}}
-      <ns2:constructionAuthorisationDeniedDate>{{echDate model.constructionAuthorisationDeniedDate}}</ns2:constructionAuthorisationDeniedDate>
-    {{/if}}
-    {{#if model.withdrawalDate}}
-      <ns2:withdrawalDate>{{echDate model.withdrawalDate}}</ns2:withdrawalDate>
-    {{/if}}
-    {{! this is accepted by the api but in the response the field is missing. Is this intended?}}
-    {{#if model.nonRealisationDate}}
-    <ns2:cancellationDate>{{echDate model.nonRealisationDate}}</ns2:cancellationDate>
-    {{/if}}
+      {{#if model.withdrawalDate}}
+        <ns2:withdrawalDate>{{echDate model.withdrawalDate}}</ns2:withdrawalDate>
+      {{/if}}
+
+      {{#if model.durationOfConstructionPhase}}
+        <ns2:durationOfConstructionPhase>{{model.durationOfConstructionPhase}}</ns2:durationOfConstructionPhase>
+      {{/if}}
+    {{/unless}}
 
     {{#if model.isNew}}
       {{! TODO}}
@@ -231,9 +237,17 @@ export default class ConstructionProject extends XMLModel {
     ],
     setToStartConstructionProject: [
       { field: "projectStartDate", type: "date", required: true },
-      { field: "durationOfConstructionPhase", type: "number", required: true },
+      {
+        field: "durationOfConstructionPhase",
+        type: "number",
+        required: true,
+        hint:
+          "ember-gwr.constructionProject.fields.durationOfConstructionPhase.hint",
+      },
     ],
-    setToCompletedConstructionProject: [],
+    setToCompletedConstructionProject: [
+      { field: "projectCompletionDate", type: "date", required: true },
+    ],
     setToCancelledSuspensionConstructionProject: [],
   };
 
@@ -260,13 +274,25 @@ export default class ConstructionProject extends XMLModel {
       { field: "projectAnnouncementDate", type: "date", required: true },
       { field: "buildingPermitIssueDate", type: "date", required: true },
       { field: "projectStartDate", type: "date", required: true },
-      { field: "durationOfConstructionPhase", type: "number", required: true },
+      {
+        field: "durationOfConstructionPhase",
+        type: "number",
+        required: true,
+        hint:
+          "ember-gwr.constructionProject.fields.durationOfConstructionPhase.hint",
+      },
     ],
     6704: [
       { field: "projectAnnouncementDate", type: "date", required: true },
       { field: "buildingPermitIssueDate", type: "date", required: true },
       { field: "projectStartDate", type: "date", required: true },
-      { field: "durationOfConstructionPhase", type: "number", required: true },
+      {
+        field: "durationOfConstructionPhase",
+        type: "number",
+        required: true,
+        hint:
+          "ember-gwr.constructionProject.fields.durationOfConstructionPhase.hint",
+      },
       { field: "projectCompletionDate", type: "date", required: true },
     ],
     6706: [
@@ -282,12 +308,16 @@ export default class ConstructionProject extends XMLModel {
         type: "date",
         required: false,
         on: "durationOfConstructionPhase",
+        hint:
+          "ember-gwr.constructionProject.fields.durationOfConstructionPhase.hint",
       },
       {
         field: "durationOfConstructionPhase",
         type: "number",
         required: false,
         on: "projectStartDate",
+        hint:
+          "ember-gwr.constructionProject.fields.durationOfConstructionPhase.hint",
       },
       { field: "projectSuspensionDate", type: "date", required: true },
     ],

--- a/addon/templates/project/form.hbs
+++ b/addon/templates/project/form.hbs
@@ -102,7 +102,12 @@
             "uk-child-width-1-4@l uk-child-width-1-3@m uk-child-width-1-2@s"
           }}"
       >
-        {{#let (unless this.import "uk-padding-small") as |spacingClass|}}
+        {{#let
+          (unless
+            this.import
+            "uk-padding uk-padding-remove-vertical uk-padding-remove-left"
+          ) as |spacingClass|
+        }}
           <div class={{spacingClass}}>
             <Field
               @inputType="date"
@@ -113,29 +118,38 @@
           <div class={{spacingClass}}>
             <Field @inputType="date" @attr="buildingPermitIssueDate" />
           </div>
-          <div class={{spacingClass}}>
-            <Field @inputType="date" @attr="projectStartDate" />
-          </div>
-          <div class={{spacingClass}}>
-            <Field @inputType="date" @attr="projectCompletionDate" />
-          </div>
-          <div class={{spacingClass}}>
-            <Field @inputType="date" @attr="projectSuspensionDate" />
-          </div>
-          <div class={{spacingClass}}>
-            <Field
-              @inputType="date"
-              @attr="constructionAuthorisationDeniedDate"
-            />
-          </div>
-          <div class={{spacingClass}}>
-            <Field @inputType="date" @attr="nonRealisationDate" />
-          </div>
-          <div class={{spacingClass}}>
-            <Field @inputType="date" @attr="withdrawalDate" />
-          </div>
+          {{#unless this.project.isNew}}
+            <div class={{spacingClass}}>
+              <Field @inputType="date" @attr="projectStartDate" />
+            </div>
+            <div class={{spacingClass}}>
+              <Field @inputType="date" @attr="projectCompletionDate" />
+            </div>
+            <div class={{spacingClass}}>
+              <Field @inputType="date" @attr="projectSuspensionDate" />
+            </div>
+            <div class={{spacingClass}}>
+              <Field
+                @inputType="date"
+                @attr="constructionAuthorisationDeniedDate"
+              />
+            </div>
+            <div class={{spacingClass}}>
+              <Field @inputType="date" @attr="nonRealisationDate" />
+            </div>
+            <div class={{spacingClass}}>
+              <Field @inputType="date" @attr="withdrawalDate" />
+            </div>
+          {{/unless}}
         {{/let}}
       </div>
+      {{#unless this.project.isNew}}
+        <Field
+          @type="number"
+          @attr="durationOfConstructionPhase"
+          @hint={{t "ember-gwr.constructionProject.fields.durationOfConstructionPhase.hint"}}
+        />
+      {{/unless}}
       <h3>
         {{t "ember-gwr.components.projectForm.realEstateHeading"}}
       </h3>

--- a/addon/validations/construction-project.js
+++ b/addon/validations/construction-project.js
@@ -22,6 +22,15 @@ export default {
   ],
   typeOfConstruction: [validatePresence(true)],
   projectAnnouncementDate: [validatePresence(true)],
+  durationOfConstructionPhase: [
+    validateNumber({
+      gte: 1,
+      lte: 999,
+      integer: true,
+      positive: true,
+      allowBlank: true,
+    }),
+  ],
   typeOfClient: [validatePresence(true)],
   client: {
     identification: {

--- a/addon/validations/status/status-project-change.js
+++ b/addon/validations/status/status-project-change.js
@@ -80,4 +80,13 @@ export default {
       model: "project",
     }),
   ],
+  projectCompletionDate: [
+    validatePresenceTransition({
+      presence: true,
+      on: "projectStatus",
+      transitions: ["setToCompletedConstructionProject"],
+      data: ConstructionProject,
+      model: "project",
+    }),
+  ],
 };

--- a/translations/construction-project/de.yaml
+++ b/translations/construction-project/de.yaml
@@ -14,6 +14,7 @@ ember-gwr:
       buildingPermitIssueDate: Datum Baubewilligung
       projectStartDate: Datum Baubeginn
       durationOfConstructionPhase: Baudauer
+      durationOfConstructionPhase.hint: Baudauer in Monaten (Zahl von 1 bis 999)
       projectCompletionDate: Datum Bauende
       projectSuspensionDate: Datum Sistierung
       constructionAuthorisationDeniedDate: Datum Ablehnung


### PR DESCRIPTION
Ensure further dates can be entered when modifying a project.
When creating a project, only the announcement and building permit
date are allowed, all other date fields are hidden.
Add duration of construction phase field to project
modification form.

**Modify project**  
![image](https://user-images.githubusercontent.com/32454507/129365587-16199fdc-0233-4cd5-b52d-0e2376790d40.png)
  
**Create project**  
![image](https://user-images.githubusercontent.com/32454507/129365673-a7985e25-3617-4528-b1f0-61fc3bf2d8c8.png)

Relates to #99