### PR TITLE
feat(linked-projects): add a visual separation to projects list

### DIFF
--- a/addon/components/linked-models.hbs
+++ b/addon/components/linked-models.hbs
@@ -3,7 +3,10 @@
   (t (concat "ember-gwr.models." @modelName) count=2)
   as |modelName modelNamePlural|
 }}
-  <table class="uk-table uk-table-divider uk-table-hover uk-table-middle">
+  <table
+    class="uk-table uk-table-divider uk-table-hover uk-table-middle"
+    ...attributes
+  >
     <thead>
       <tr>
         <th colspan="3">

--- a/addon/components/linked-projects.hbs
+++ b/addon/components/linked-projects.hbs
@@ -3,6 +3,7 @@
   @modelName="project"
   @searchRoute="search-project"
   @newRoute="project.new"
+  ...attributes
   as |project|
 >
   <td

--- a/addon/templates/project.hbs
+++ b/addon/templates/project.hbs
@@ -7,11 +7,13 @@
     {{#if this.displayLandingPage}}
       <LandingPage />
     {{else}}
-      <LinkedProjects
-        @projects={{this.projects}}
-        @activeProject={{this.activeProject}}
-        @removeProject={{this.removeProjectLink}}
-      />
+      <div class="linked-projects">
+        <LinkedProjects
+          @projects={{this.projects}}
+          @activeProject={{this.activeProject}}
+          @removeProject={{this.removeProjectLink}}
+        />
+      </div>
       <UkTab as |Tab|>
         <Tab.link-item @route="project.form" @model={{this.activeProject}}>
           {{t "ember-gwr.models.project" count=1}}

--- a/app/styles/ember-ebau-gwr.scss
+++ b/app/styles/ember-ebau-gwr.scss
@@ -3,7 +3,6 @@
 @import "ember-power-select";
 
 .ebau-gwr {
-
   .ember-ebau-gwr-login .ember-power-select-status-icon {
     @extend .uk-invisible;
   }
@@ -18,7 +17,6 @@ $ember-ebau-gwr-required-color: $alert-danger-color !default;
   text-decoration: none;
   min-height: $spinner-size;
 }
-
 
 .uk-highlight-hover:hover {
   @extend .uk-text-muted;
@@ -81,5 +79,25 @@ $ember-ebau-gwr-required-color: $alert-danger-color !default;
 
   path {
     stroke-width: 2;
+  }
+}
+
+.linked-projects {
+  @extend .uk-box-shadow-small, .uk-margin-large, .uk-padding-small, .uk-background-muted;
+  border: 1px solid #e5e5e5;
+
+  table {
+    @extend .uk-margin-remove-bottom;
+
+    tr {
+      td:first-child,
+      th:first-child {
+        padding-left: 50px;
+      }
+
+      td:last-child {
+        padding-right: 50px;
+      }
+    }
   }
 }


### PR DESCRIPTION
This change mainly helps to differentiate the project list from the linked building list.

@luytena Would be awesome to have some thought from you about this design implementation!

# Before
![image](https://user-images.githubusercontent.com/15276514/129368757-2510eabe-018c-4cb5-ae18-a6d7454a1a9d.png)
![image](https://user-images.githubusercontent.com/15276514/129368791-0e3eae23-bec4-479a-bf1f-fd57ab86253c.png)
# After
![image](https://user-images.githubusercontent.com/15276514/129368925-d74fb85e-254d-42ab-9140-9a6b038e9929.png)
![image](https://user-images.githubusercontent.com/15276514/129368884-e421fd30-f804-4f6f-8d01-30b6b60a01c3.png)

