### PR TITLE
fix(project): correct confirmation dialog modal container

### DIFF
--- a/addon/components/link-building-modal.hbs
+++ b/addon/components/link-building-modal.hbs
@@ -1,7 +1,7 @@
 <UkModal
   @visible={{@visible}}
   @on-hide={{@close}}
-  @container="#ember-camac-ng"
+  @container={{this.config.modalContainer}}
   as |Modal|
 >
   <Modal.header>

--- a/addon/components/link-building-modal.js
+++ b/addon/components/link-building-modal.js
@@ -1,8 +1,10 @@
+import { inject as service } from "@ember/service";
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import BuildingWork from "ember-ebau-gwr/models/building-work";
 
 export default class LinkBuildingModalComponent extends Component {
+  @service config;
   @tracked buildingWork = new BuildingWork();
   // Remove the state "Neubau" from the array since you cant link
   // existing buildings as "Neubau".

--- a/addon/templates/project/form.hbs
+++ b/addon/templates/project/form.hbs
@@ -331,11 +331,12 @@
   {{/if}}
 </div>
 
-<UkModal 
+<UkModal
   @visible={{this.showConfirmationDialog}}
   @btnClose={{false}}
   @bgClose={{false}}
   @escClose={{false}}
+  @container={{this.config.modalContainer}}
   as |modal|
 >
   <modal.header>
@@ -351,13 +352,13 @@
     {{/if}}
   </modal.body>
   <modal.footer @class="uk-text-right">
-    <UkButton 
-      @color="default" 
-      @label={{t "ember-gwr.components.modelForm.project.confirmationContinue"}} 
+    <UkButton
+      @color="default"
+      @label={{t "ember-gwr.components.modelForm.project.confirmationContinue"}}
       {{on "click" (perform this.processTypeOfConstructionProjectChange)}}
     />
-    <UkButton 
-      @color="primary" 
+    <UkButton
+      @color="primary"
       @label={{t "ember-gwr.components.modelForm.project.confirmationCancel"}}
       {{on "click" this.cancelTypeOfConstructionProjectChange}}
     />

--- a/tests/dummy/app/services/gwr-config.js
+++ b/tests/dummy/app/services/gwr-config.js
@@ -12,4 +12,6 @@ export default class GwrConfigService extends Service {
   get camacGroup() {
     return "1";
   }
+
+  modalContainer = "#modal-container";
 }

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -12,7 +12,7 @@
   </li>
 </ul>
 
-<div id="ember-camac-ng"></div>
+<div id="modal-container"></div>
 <div class="uk-padding uk-container">
   {{outlet}}
 </div>


### PR DESCRIPTION
Ensure the confirmation dialog modal when changing the type of
the construction project (superstructure/infrastructure) is
added to the correct modal container.