### PR TITLE
fix(project): replace non-realisation date with cancellation date

### DIFF
--- a/addon/models/construction-project.js
+++ b/addon/models/construction-project.js
@@ -27,7 +27,7 @@ export default class ConstructionProject extends XMLModel {
   @tracked projectStartDate;
   @tracked durationOfConstructionPhase;
   @tracked constructionAuthorisationDeniedDate;
-  @tracked nonRealisationDate;
+  @tracked cancellationDate;
   @tracked projectCompletionDate;
   @tracked projectSuspensionDate;
   @tracked buildingPermitIssueDate;
@@ -60,7 +60,7 @@ export default class ConstructionProject extends XMLModel {
         projectStartDate: String,
         durationOfConstructionPhase: Number,
         constructionAuthorisationDeniedDate: String,
-        nonRealisationDate: String,
+        cancellationDate: String,
         projectCompletionDate: String,
         projectSuspensionDate: String,
         buildingPermitIssueDate: String,
@@ -96,7 +96,7 @@ export default class ConstructionProject extends XMLModel {
         ? this.STATUS_COMPLETED
         : this.withdrawalDate
         ? this.STATUS_WITHDRAWN
-        : this.nonRealisationDate
+        : this.cancellationDate
         ? this.STATUS_NOT_REALIZED
         : this.constructionAuthorisationDeniedDate
         ? this.STATUS_REFUSED
@@ -141,7 +141,7 @@ export default class ConstructionProject extends XMLModel {
 
       {{! this is accepted by the api but in the response the field is missing. Is this intended?}}
       {{{modelField model "withdrawalDate" value=(echDate model.withdrawalDate)}}}
-      {{{modelField model "cancellationDate" value=(echDate model.nonRealisationDate)}}}
+      {{{modelField model "cancellationDate" value=(echDate model.cancellationDate)}}}
       {{{modelField model "durationOfConstructionPhase"}}}
     {{/unless}}
 
@@ -254,7 +254,7 @@ export default class ConstructionProject extends XMLModel {
       { field: "withdrawalDate", type: "date", required: true },
     ],
     setToCancelledConstructionProject: [
-      { field: "nonRealisationDate", type: "date", required: true },
+      { field: "cancellationDate", type: "date", required: true },
     ],
     setToSuspendedConstructionProject: [
       { field: "projectSuspensionDate", type: "date", required: true },
@@ -288,7 +288,7 @@ export default class ConstructionProject extends XMLModel {
     "projectCompletionDate",
     "projectSuspensionDate",
     "constructionAuthorisationDeniedDate",
-    "nonRealisationDate",
+    "cancellationDate",
     "withdrawalDate",
   ];
 
@@ -363,7 +363,7 @@ export default class ConstructionProject extends XMLModel {
     [this.STATUS_NOT_REALIZED]: [
       { field: "projectAnnouncementDate", type: "date", required: true },
       { field: "buildingPermitIssueDate", type: "date", required: false },
-      { field: "nonRealisationDate", type: "date", required: true },
+      { field: "cancellationDate", type: "date", required: true },
     ],
     [this.STATUS_WITHDRAWN]: [
       { field: "projectAnnouncementDate", type: "date", required: true },

--- a/addon/templates/project/form.hbs
+++ b/addon/templates/project/form.hbs
@@ -197,9 +197,9 @@
                 />
               </div>
             {{/if}}
-            {{#if this.project.nonRealisationDate}}
+            {{#if this.project.cancellationDate}}
               <div class={{spacingClass}}>
-                <Field @inputType="date" @attr="nonRealisationDate" />
+                <Field @inputType="date" @attr="cancellationDate" />
               </div>
             {{/if}}
             {{#if this.project.withdrawalDate}}

--- a/addon/validations/status/status-project-change.js
+++ b/addon/validations/status/status-project-change.js
@@ -44,7 +44,7 @@ export default {
       model: "project",
     }),
   ],
-  nonRealisationDate: [
+  cancellationDate: [
     validatePresenceTransition({
       presence: true,
       on: "projectStatus",

--- a/addon/validations/status/status-project-correction.js
+++ b/addon/validations/status/status-project-correction.js
@@ -94,7 +94,7 @@ export default {
       states: [ConstructionProject.STATUS_REFUSED],
     }),
   ],
-  nonRealisationDate: [
+  cancellationDate: [
     validatePresenceState({
       presence: true,
       on: "projectStatus",

--- a/addon/xml/templates/construction-project.js
+++ b/addon/xml/templates/construction-project.js
@@ -48,8 +48,7 @@ export const setToWithdrawnConstructionProject =
 export const setToCancelledConstructionProject =
 `{{#>base}}
   <ns2:setToCancelledConstruction>
-    {{! TODO check if should be nonRealisationDate and if state is accepted}}
-    <ns2:cancellationDate>{{echDate model.nonRealisationDate}}</ns2:cancellationDate>
+    <ns2:cancellationDate>{{echDate model.cancellationDate}}</ns2:cancellationDate>
   </ns2:setToCancelledConstruction>
 {{/base}}`;
 

--- a/translations/construction-project/de.yaml
+++ b/translations/construction-project/de.yaml
@@ -21,7 +21,7 @@ ember-gwr:
       projectCompletionDate: Datum Bauende
       projectSuspensionDate: Datum Sistierung
       constructionAuthorisationDeniedDate: Datum Ablehnung
-      nonRealisationDate: Datum Nichtrealisierung
+      cancellationDate: Datum Nichtrealisierung
       withdrawalDate: Datum Rückzung des Baugesuchs
       projectFreeText1: Freitext Project 1
       projectFreeText2: Freitext Project 2


### PR DESCRIPTION
The API returns the cancellation date instead of the non-
realisation date. All references to that field are updated
accordingly.