### PR TITLE
feat(building): enable building entrance deactivation

### DIFF
--- a/addon/models/building-entrance.js
+++ b/addon/models/building-entrance.js
@@ -71,4 +71,7 @@ export default class BuildingEntrance extends XMLModel {
     </ns2:buildingEntrance>
   {{/if}}
   `;
+
+  static DEACTIVATION_ERROR =
+    "Cannot deactivate an entrance while active dwellings are still linked to it";
 }

--- a/addon/services/building-entrance.js
+++ b/addon/services/building-entrance.js
@@ -97,7 +97,7 @@ export default class BuildingEntranceService extends GwrService {
     );
     if (!response.ok) {
       const xmlErrors = await response.text();
-      const errors = this.extractErrorsFromXML(xmlErrors);
+      const errors = this.extractErrorsFromXML(xmlErrors, false);
 
       console.error("GWR API: deactivateBuildingEntrance failed");
       throw errors;

--- a/addon/services/gwr.js
+++ b/addon/services/gwr.js
@@ -88,7 +88,7 @@ export default class GwrService extends Service {
     })[searchKey];
   }
 
-  extractErrorsFromXML(xml) {
+  extractErrorsFromXML(xml, showGeneral = true) {
     const model = new XMLModel(xml);
     model.setFieldsFromXML({
       fields: {
@@ -99,7 +99,9 @@ export default class GwrService extends Service {
 
     const errors = [
       ...(model.error
-        ? [this.intl.t("ember-gwr.generalErrors.genericFormError")]
+        ? showGeneral
+          ? [this.intl.t("ember-gwr.generalErrors.genericFormError")]
+          : model.error
         : []),
       ...(model.errorList
         ? model.errorList.map((error) => error.messageOfError)

--- a/addon/templates/building/edit/entrances.hbs
+++ b/addon/templates/building/edit/entrances.hbs
@@ -5,14 +5,17 @@
     </div>
   {{else}}
     <LinkedModels
-      @models={{this.fetchEntrances.lastSuccessful.value}}
+      @models={{this.entrances}}
       @modelName="entrance"
       @newRoute="building.edit.entrance.new"
       {{!--
       TODO removing a entrance is not allowed if there is still a dwelling attached to it
-      We also cannot remove an entrance if there is only one.
-      @removeLink={{this.removeEntranceLink}}
+      We also cannot remove an entrance if there is only one. This only applies for active
+      instances of dwellings and building entrances. Since building entrance deactivation 
+      is an asynchronous process, we should check the mutation status of deactivated
+      building entrances and dwellings, to ensure that the requirements hold.
       --}}
+      @removeLink={{if (gt this.entrances.length 1) this.removeEntranceLink}}
       as |model|
     >
       <td class="uk-table-shrink">

--- a/translations/building/de.yaml
+++ b/translations/building/de.yaml
@@ -29,6 +29,8 @@ ember-gwr:
     entrances:
       error: Beim Laden der Eingänge ist ein Fehler aufgetreten.
       removeLinkError: Beim Entfernen der Verknüpfung ist ein Fehler aufgetreten.
+      attachedDwellingsError: Alle verknüpften Wohnungen müssen deaktiviert werden bevor der Eingang entfernt werden kann.
+      removeLinkSuccess: "Ihre Anfrage wurde vom BfS erfasst. Das Support-Team wird Ihre Anfrage bearbeiten und Sie, falls nötig kontaktieren. Telefon: 0800 866 600 E-mail: housing-stat@bfs.admin.ch"
     dwellings:
       entrance: Eingang {number}
       rooms: "{number} Zimmer"


### PR DESCRIPTION
Trigger a request for building entrance deactivation if at least
one building entrance is attached to the building. Show appropriate
error message if API request fails due to active dwellings
attached to the building entrance.