### PR TITLE
fix(project/new): extend new route from form route

### DIFF
--- a/addon/routes/project/new.js
+++ b/addon/routes/project/new.js
@@ -1,8 +1,9 @@
-import Route from "@ember/routing/route";
 import { inject as service } from "@ember/service";
 import ConstructionProject from "ember-ebau-gwr/models/construction-project";
 
-export default class ProjectNewRoute extends Route {
+import FormRoute from "./form";
+
+export default class ProjectNewRoute extends FormRoute {
   @service constructionProject;
   @service config;
 


### PR DESCRIPTION
Since we moved the fetchProject call from the {{did-insert}} to the setupController
we need to extend the new route from the edit route.
