### PR TITLE
fix(life-cycles): correct life cycle error links for camac-ng

### DIFF
--- a/addon/components/model-form/header/status-selector.hbs
+++ b/addon/components/model-form/header/status-selector.hbs
@@ -135,7 +135,7 @@
         </div>
       </div>
     {{/if}}
-    {{#if this.errors.length}}
+    {{#if (or this.errors.length this.errors.linkToRoute)}}
       <div class="uk-flex-inline">
         <ModelForm::SubmitErrors @errors={{this.errors}} />
       </div>

--- a/addon/components/model-form/header/status-selector/submit-parameters.hbs
+++ b/addon/components/model-form/header/status-selector/submit-parameters.hbs
@@ -65,7 +65,7 @@
           {{@confirmLabel}}
         </UkButton>
       </div>
-      {{#if @errors.length}}
+      {{#if (or @errors.length @errors.linkToRoute)}}
         <div class="uk-margin-small-top">
           <ModelForm::SubmitErrors @errors={{@errors}} />
         </div>

--- a/addon/components/model-form/submit-errors.hbs
+++ b/addon/components/model-form/submit-errors.hbs
@@ -1,26 +1,44 @@
-{{#if @errors}}
-  {{#if (eq @errors.length 1)}}
-    <div
-      class="uk-alert-danger uk-text-small uk-flex-1 uk-margin-remove-bottom"
-      uk-alert
+{{#if @errors.linkToRoute}}
+  <div
+    class="uk-alert-danger uk-text-small uk-flex-1 uk-margin-remove-bottom"
+    uk-alert
+  >
+    <LinkTo
+      class="uk-text-danger uk-text-small"
+      @route={{@errors.linkToRoute}}
+      @models={{@errors.linkToModels}}
     >
-      {{object-at 0 @errors}}
-    </div>
-  {{else}}
-    <button
-      type="button"
-      class="uk-button ember-ebau-gwr-submit-errors-multiple uk-alert-danger uk-text-small uk-flex-1 uk-margin-remove-bottom"
-      uk-alert
-      {{on "click" this.updateCurrentIndex}}
-    >
-      <div class="uk-flex-inline uk-flex-middle">
-        <div class="uk-text-small uk-margin-small-right">
-          {{inc this.errorIndex}}<span>/</span>{{@errors.length}}
-        </div>
-        <div>
-          {{object-at this.errorIndex @errors}}
-        </div>
+      {{@errors.linkToText}}
+    </LinkTo>
+    <span>
+      {{@errors.linkToTextAfter}}
+    </span>
+  </div>
+{{else if (eq @errors.length 1)}}
+  <div
+    class="uk-alert-danger uk-text-small uk-flex-1 uk-margin-remove-bottom"
+    uk-alert
+  >
+    {{object-at 0 @errors}}
+  </div>
+{{else if (gt @errors.length 1)}}
+  <button
+    type="button"
+    class="uk-button ember-ebau-gwr-submit-errors-multiple uk-alert-danger uk-text-small uk-flex-1 uk-margin-remove-bottom"
+    uk-alert
+    {{on "click" this.updateCurrentIndex}}
+  >
+    <div class="uk-flex-inline uk-flex-middle">
+      <div class="uk-text-small uk-margin-small-right">
+        {{inc this.errorIndex}}
+        <span>
+          /
+        </span>
+        {{@errors.length}}
       </div>
-    </button>
-  {{/if}}
+      <div>
+        {{object-at this.errorIndex @errors}}
+      </div>
+    </div>
+  </button>
 {{/if}}

--- a/addon/services/gwr.js
+++ b/addon/services/gwr.js
@@ -111,14 +111,6 @@ export default class GwrService extends Service {
     return errors;
   }
 
-  get basePath() {
-    const mountPoint = `#/${this.config.mountPoint}`;
-    const href = window.location.href;
-    return href.includes(mountPoint)
-      ? `${href.split(mountPoint, 1)}${mountPoint}`
-      : "";
-  }
-
   concatStates(states) {
     if (states.length === 1) {
       return this.intl.t(`ember-gwr.lifeCycles.states.${states[0]}`);
@@ -132,19 +124,29 @@ export default class GwrService extends Service {
   }
 
   buildLifeCycleError(error, { instanceId, projectId }) {
-    const errorType = error.dwellingId
-      ? "statusErrorDwelling"
-      : "statusErrorBuilding";
-    return [
-      this.intl.t(`ember-gwr.lifeCycles.${errorType}`, {
-        dwellingId: error.dwellingId,
-        buildingId: error.buildingId,
-        states: this.concatStates(error.states),
-        href: `${this.basePath}/${instanceId}/${projectId}/building/${
-          error.buildingId
-        }/${error.dwellingId ? `dwelling/${error.dwellingId}` : `form`}`,
-        htmlSafe: true,
+    const { buildingId, dwellingId, states } = error;
+    return {
+      linkToRoute: dwellingId
+        ? "building.edit.dwelling.edit"
+        : "building.edit.form",
+      linkToModels: [
+        instanceId,
+        projectId,
+        buildingId,
+        ...(dwellingId ? [dwellingId] : []),
+      ],
+      linkToText: this.intl.t(
+        `ember-gwr.lifeCycles.statusError${
+          dwellingId ? "Dwelling" : "Building"
+        }`,
+        {
+          dwellingId,
+          buildingId,
+        }
+      ),
+      linkToTextAfter: this.intl.t(`ember-gwr.lifeCycles.statusError`, {
+        states: this.concatStates(states),
       }),
-    ];
+    };
   }
 }

--- a/addon/services/gwr.js
+++ b/addon/services/gwr.js
@@ -110,4 +110,41 @@ export default class GwrService extends Service {
 
     return errors;
   }
+
+  get basePath() {
+    const mountPoint = `#/${this.config.mountPoint}`;
+    const href = window.location.href;
+    return href.includes(mountPoint)
+      ? `${href.split(mountPoint, 1)}${mountPoint}`
+      : "";
+  }
+
+  concatStates(states) {
+    if (states.length === 1) {
+      return this.intl.t(`ember-gwr.lifeCycles.states.${states[0]}`);
+    }
+    const tail = states.pop();
+    return `${states
+      .map((state) => this.intl.t(`ember-gwr.lifeCycles.states.${state}`))
+      .join(", ")} ${this.intl.t("ember-gwr.general.or")} ${this.intl.t(
+      `ember-gwr.lifeCycles.states.${tail}`
+    )}`;
+  }
+
+  buildLifeCycleError(error, { instanceId, projectId }) {
+    const errorType = error.dwellingId
+      ? "statusErrorDwelling"
+      : "statusErrorBuilding";
+    return [
+      this.intl.t(`ember-gwr.lifeCycles.${errorType}`, {
+        dwellingId: error.dwellingId,
+        buildingId: error.buildingId,
+        states: this.concatStates(error.states),
+        href: `${this.basePath}/${instanceId}/${projectId}/building/${
+          error.buildingId
+        }/${error.dwellingId ? `dwelling/${error.dwellingId}` : `form`}`,
+        htmlSafe: true,
+      }),
+    ];
+  }
 }

--- a/tests/dummy/app/services/gwr-config.js
+++ b/tests/dummy/app/services/gwr-config.js
@@ -6,7 +6,6 @@ export default class GwrConfigService extends Service {
   gwrAPI = "http://localhost:8010/proxy/regbl/api/ech0216/2";
   modalContainer = "#modal-container";
   housingStatLink = "https://www-r.housing-stat.ch";
-  mountPoint = "gwr";
 
   get authToken() {
     return "token";

--- a/tests/dummy/app/services/gwr-config.js
+++ b/tests/dummy/app/services/gwr-config.js
@@ -6,6 +6,7 @@ export default class GwrConfigService extends Service {
   gwrAPI = "http://localhost:8010/proxy/regbl/api/ech0216/2";
   modalContainer = "#modal-container";
   housingStatLink = "https://www-r.housing-stat.ch";
+  mountPoint = "gwr";
 
   get authToken() {
     return "token";

--- a/translations/de.yaml
+++ b/translations/de.yaml
@@ -138,8 +138,9 @@ ember-gwr:
         3007: Aufgehoben
         3008: Nicht realisiert
 
-    statusErrorBuilding: <a href="{href}">Gebäude {buildingId}</a> muss im Status {states} sein.
-    statusErrorDwelling: <a href="{href}">Wohnung {dwellingId}</a> im Gebäude {buildingId} muss im Status {states} sein.
+    statusErrorBuilding: Gebäude {buildingId}
+    statusErrorDwelling: Wohnung {dwellingId} im Gebäude {buildingId}
+    statusError: muss im Status {states} sein.
 
     states:
       6701: projektiert


### PR DESCRIPTION
Prepend the current url base path to the error links to ensure
that links direct to the correct location when gwr is mounted
as an engine.