### PR TITLE
ci(release): set node version to v14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
+        with:
+          node-version: 14
 
       - name: Install dependencies
         run: yarn install


### PR DESCRIPTION
ember-validated-form dropped node v10 support
