### PR TITLE
feat(search): add back routes for building and project search

### DIFF
--- a/addon/components/back-route.hbs
+++ b/addon/components/back-route.hbs
@@ -1,0 +1,10 @@
+{{#if @backRoute}}
+  <LinkTo
+    @route={{@backRoute}}
+    @models={{if @backModel (array @backModel) (array)}}
+    class="uk-link-muted uk-margin-small-bottom"
+  >
+    <span uk-icon="icon: arrow-left"></span>
+    {{@backText}}
+  </LinkTo>
+{{/if}}

--- a/addon/components/sub-nav.hbs
+++ b/addon/components/sub-nav.hbs
@@ -1,14 +1,9 @@
 {{#unless this.isHidden}}
-  {{#if @backRoute}}
-    <LinkTo
-      @route={{@backRoute}}
-      @models={{if @backModel (array @backModel) (array)}}
-      class="uk-link-muted uk-margin-small-bottom"
-    >
-      <span uk-icon="icon: arrow-left"></span>
-      {{@backText}}
-    </LinkTo>
-  {{/if}}
+  <BackRoute
+    @backRoute={{@backRoute}}
+    @backModel={{@backModel}}
+    @backText={{@backText}}
+  />
   <UkTab ...attributes as |Tab|>
     {{#each @links as |link|}}
       <Tab.link-item @route={{link.route}} @models={{link.models}}>

--- a/addon/templates/search-building.hbs
+++ b/addon/templates/search-building.hbs
@@ -1,3 +1,9 @@
+<BackRoute 
+  @backRoute="project.linked-buildings" 
+  @backModel={{@model}}
+  @backText={{t "ember-gwr.building.backToProject"}}
+/>
+
 <h1>
   {{t "ember-gwr.searchBuilding.heading"}}
 </h1>

--- a/addon/templates/search-project.hbs
+++ b/addon/templates/search-project.hbs
@@ -1,3 +1,9 @@
+<BackRoute 
+  @backRoute="project" 
+  @backModel={{@model}}
+  @backText={{t "ember-gwr.building.backToProject"}}
+/>
+
 <h1>
   {{t "ember-gwr.searchProject.heading"}}
 </h1>


### PR DESCRIPTION
Enable the user to return to the previous route after
entering the project search or building search route.