### PR TITLE
refactor(header): environment-dependent housing-stat link and improve…

### DIFF
--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -2,5 +2,8 @@
 
 module.exports = {
   extends: "octane",
-  rules: { "no-bare-strings": true },
+  rules: {
+    "no-bare-strings": true,
+    "no-implicit-this": { allow: ["housing-stat-link"] },
+  },
 };

--- a/addon/helpers/housing-stat-link.js
+++ b/addon/helpers/housing-stat-link.js
@@ -1,0 +1,13 @@
+import Helper from "@ember/component/helper";
+import { inject as service } from "@ember/service";
+import ENV from "ember-ebau-gwr/config/environment";
+
+export default class HousingStatLink extends Helper {
+  @service config;
+
+  compute() {
+    return this.config.isTestEnvironment === false
+      ? ENV.housingStatLinkProd
+      : ENV.housingStatLinkTest;
+  }
+}

--- a/addon/templates/project.hbs
+++ b/addon/templates/project.hbs
@@ -22,23 +22,29 @@
           class="uk-margin-remove"
         >
           <div class="uk-flex uk-flex-between uk-flex-middle">
-            <span class="uk-flex-inline uk-flex-middle">
-              <span uk-icon="icon: info" class="uk-margin-small-right"></span>
-              <span>
-                {{t "ember-gwr.nav.housingStatInfo"}}
-              </span>
-            </span>
-            <a
-              class="uk-button uk-button-default"
-              href={{this.config.housingStatLink}}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              {{t "ember-gwr.nav.housingStatLink"}}
-            </a>
-          </div>
-          <div>
-            {{t "ember-gwr.nav.deletionInfo"}}
+            <div class="uk-flex uk-flex-middle uk-width-expand uk-margin-right">
+              <div class="uk-flex-none uk-margin-right">
+                <span uk-icon="icon: info"></span>
+              </div>
+              <div>
+                <div>
+                  {{t "ember-gwr.nav.housingStatInfo"}}
+                </div>
+                <div>
+                 {{t "ember-gwr.nav.deletionInfo"}} 
+                </div>
+              </div>
+            </div>
+            <div class="uk-width-auto">
+              <a
+                class="uk-button uk-button-default"
+                href={{housing-stat-link}}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {{t "ember-gwr.nav.housingStatLink"}}
+              </a>
+            </div>
           </div>
         </div>
       </div>

--- a/config/environment.js
+++ b/config/environment.js
@@ -5,6 +5,9 @@ module.exports = function (environment) {
     modulePrefix: "ember-ebau-gwr",
     environment,
 
+    housingStatLinkTest: "https://www-r.housing-stat.ch",
+    housingStatLinkProd: "https://www.housing-stat.ch",
+
     "ember-validated-form": {
       theme: "uikit",
       defaults: {

--- a/tests/dummy/app/services/gwr-config.js
+++ b/tests/dummy/app/services/gwr-config.js
@@ -5,7 +5,7 @@ export default class GwrConfigService extends Service {
   cantonAbbreviation = "SZ";
   gwrAPI = "http://localhost:8010/proxy/regbl/api/ech0216/2";
   modalContainer = "#modal-container";
-  housingStatLink = "https://www-r.housing-stat.ch";
+  isTestEnvironment = true;
 
   get authToken() {
     return "token";


### PR DESCRIPTION
…d styling

Use correct housing-stat link, depending on whether the application
is running in a prod or test environment. In addition, ensure
that the housing-stat information and link are displayed nicely
for smaller screen sizes.