### PR TITLE
feat(linked-models): clarification info for object additions

### DIFF
--- a/addon/components/linked-models.hbs
+++ b/addon/components/linked-models.hbs
@@ -51,11 +51,15 @@
             <LinkTo
               @route={{@searchRoute}}
               @models={{or @searchModels (array)}}
-            >
-              {{t
-                "ember-gwr.components.linkedModels.linkEntry"
-                modelName=modelName
-              }}
+            > 
+              {{#if (eq @modelName "building")}}
+                {{t "ember-gwr.components.linkedModels.linkExistingBuilding"}}
+              {{else}}
+                {{t
+                  "ember-gwr.components.linkedModels.linkEntry"
+                  modelName=modelName
+                }}
+              {{/if}}
             </LinkTo>
           {{/if}}
           {{#if (and @searchRoute @newRoute)}}
@@ -66,6 +70,7 @@
               {{t
                 "ember-gwr.components.linkedModels.createEntry"
                 modelName=modelName
+                model=@modelName 
               }}
             </LinkTo>
           {{else if @addLink}}
@@ -77,6 +82,7 @@
               {{t
                 "ember-gwr.components.linkedModels.createEntry"
                 modelName=modelName
+                model=@modelName
               }}
             </button>
           {{/if}}

--- a/addon/templates/project/linked-buildings.hbs
+++ b/addon/templates/project/linked-buildings.hbs
@@ -61,5 +61,13 @@
         }}
       </td>
     </LinkedModels>
+    <div class="uk-flex uk-flex-middle uk-flex-center">
+      <div>
+        <span uk-icon="info" class="uk-margin-small-right"/>
+      </div>
+      <div>
+        {{t "ember-gwr.components.linkedModels.buildingInfo"}}
+      </div>
+    </div>
   {{/if}}
 </div>

--- a/translations/de.yaml
+++ b/translations/de.yaml
@@ -274,9 +274,18 @@ ember-gwr:
       linkedEntries: Verknüpfte {modelName}
       noLinkedEntries: Es sind noch keine {modelName} verknüpft
       linkEntry: "{modelName} verknüpfen"
-      createEntry: "{modelName} erfassen"
+      linkExistingBuilding: Bestehendes Gebäude verknüpfen (Umbau / Abbruch)
+      createEntry: |-
+        {modelName} erfassen 
+        {model, select, 
+          project {}
+          other {(Neubau)}
+        }
       or: oder
       removeLink: Verknüpfung aufheben
+      buildingInfo: |-
+        Um ein bestehendes Gebäude welches sich nicht im GWR befindet nachzutragen, 
+        wenden Sie sich bitte an das Housing-Stat Portal.
 
     linkBuildingModal:
       linkBuilding: Gebäude verknüpfen


### PR DESCRIPTION
Display info to clarify that creating new buildings or dwellings
is for projected objects only.