### PR TITLE
fix(dwelling): refetch dwellings after dwelling update

### DIFF
--- a/addon/controllers/building/edit/dwelling/edit.js
+++ b/addon/controllers/building/edit/dwelling/edit.js
@@ -105,10 +105,10 @@ export default class BuildingEditDwellingEditController extends ImportController
             this.model.buildingId,
             this.dwelling
           );
-          // Ensure dwelling list is refreshed
-          this.building.clearCache(this.model.buildingId);
         }
       }
+      // Ensure dwelling list is refreshed
+      this.building.clearCache(this.model.buildingId);
       this.errors = [];
       this.notification.success(this.intl.t("ember-gwr.dwelling.saveSuccess"));
     } catch (error) {


### PR DESCRIPTION
Ensure dwellings are refetched after a dwelling update. This
ensures that the information is up-to-date in the dwellings
list.