### PR TITLE
fix(project): add hints for typeOfConstructionProject

### DIFF
--- a/addon/controllers/project/form.js
+++ b/addon/controllers/project/form.js
@@ -305,6 +305,12 @@ export default class ProjectFormController extends ImportController {
   @action
   cancelTypeOfConstructionProjectChange() {
     this.showConfirmationDialog = false;
+    // Reset the type of construction project set on model during submit
+    // This ensures that the buildings tab is correctly (in)activated
+    this.project.typeOfConstructionProject =
+      this.typeOfConstructionProject === 6011 ? 6010 : 6011;
+
+    this.typeOfConstructionProject = this.project.typeOfConstructionProject;
   }
 
   get workWithoutBuildings() {

--- a/addon/templates/project/form.hbs
+++ b/addon/templates/project/form.hbs
@@ -62,13 +62,18 @@
         @attr="typeOfConstructionProject"
         @gwrEnumOptions={{this.choiceOptions.typeOfConstructionProjectOptions}}
         @on-update={{fn (mut this.typeOfConstructionProject)}}
-        @hint={{t "ember-gwr.linkedBuildings.buildingDisabledForInfrastructure"}}
+        @hint={{if 
+          (eq this.typeOfConstructionProject 6010) 
+          (t "ember-gwr.linkedBuildings.buildingDisabledForInfrastructure") 
+          (if (eq this.typeOfConstructionProject 6011)
+            (t "ember-gwr.linkedBuildings.superstructureInfo"))
+        }}
       />
 
       {{#if (eq this.typeOfConstructionProject 6010)}}
         <LinkedModels
           @models={{this.workWithoutBuildings}}
-          @modelName="building-work"
+          @modelName="building-work-infrastructure"
           @removeLink={{if (gt this.project.work.length 1) this.removeWorkLink}}
           @addLink={{this.addWorkLink}}
           as |model|

--- a/translations/de.yaml
+++ b/translations/de.yaml
@@ -11,6 +11,11 @@ ember-gwr:
         one {Arbeit}
         other {Arbeiten}
       }
+    building-work-infrastructure: |-
+      {count, plural,
+        one {Tiefbauarbeit}
+        other {Tiefbauarbeiten}
+      }
     project: |-
       {count, plural,
         one {Projekt}
@@ -52,7 +57,11 @@ ember-gwr:
   linkedBuildings:
     error: Beim Laden der Projektdaten ist ein Fehler aufgetreten.
     removeLinkError: Beim Entfernen der Verknüpfung ist ein Fehler aufgetreten.
-    buildingDisabledForInfrastructure: Für Tiefbauprojekte sind keine Gebäude zugelassen.
+    buildingDisabledForInfrastructure: |-
+      Für Tiefbauprojekte sind keine Gebäude zugelassen.
+      Die Art der Arbeiten werden direkt auf dem Projekt erfasst.
+    superstructureInfo: |-
+      Für Hochbauprojekte werden die Art der Arbeiten ausschliesslich gebäudebezogen gemeldet.
     buildingDisabledForNewProject: Während des Erstellens eines Projektes können noch keine Gebäude erfasst werden.
 
   searchBuilding:


### PR DESCRIPTION
Add additional hints for typeOfConstructionProject to ensure
that users know what the differences between superstructure
and infrastructure projects are. In addition, ensure that
the typeOfConstructionProject is reset after a change
cancellation to ensure that the buildings tab is correctly
(in-)activated.