### PR TITLE
feat(import): show floor type/number in dwelling import modal

### DIFF
--- a/addon/components/import-modal/dwelling-data.hbs
+++ b/addon/components/import-modal/dwelling-data.hbs
@@ -1,6 +1,15 @@
 <span class="uk-flex uk-child-width-1-2">
   <span>{{t "ember-gwr.dwelling.floor"}}</span>
-  <span class="uk-text-muted">{{or @model.floor "-"}}</span>
+  <span class="uk-text-muted">
+    {{#if @model.floorType}}
+      {{concat 
+        (if @model.floorNumber (concat @model.floorNumber ". ")) 
+        (t (concat "ember-gwr.dwelling.floorTypeOptions." @model.floorType))
+      }}
+    {{else}}
+      {{"-"}}
+    {{/if}}
+  </span>
 </span>
 <hr />
 <span class="uk-flex uk-child-width-1-2">

--- a/tests/dummy/app/services/data-import.js
+++ b/tests/dummy/app/services/data-import.js
@@ -70,6 +70,8 @@ export default class DataImport extends Service {
       {
         EDID: 0, // not sure if information can be given
         floor: 3100,
+        floorType: 3100,
+        floorNumber: null,
         dwellingStatus: 3001,
         noOfHabitableRooms: 8,
         locationOfDwellingOnFloor: "Rechts",
@@ -80,6 +82,8 @@ export default class DataImport extends Service {
       {
         EDID: 0,
         floor: 3101,
+        floorType: 3101,
+        floorNumber: 1,
         dwellingStatus: 3002,
         noOfHabitableRooms: 3,
         locationOfDwellingOnFloor: "Links",
@@ -90,6 +94,8 @@ export default class DataImport extends Service {
       {
         EDID: 0,
         floor: 3102,
+        floorType: 3101,
+        floorNumber: 2,
         noOfHabitableRooms: 3,
         locationOfDwellingOnFloor: "Links",
         dwellingStatus: 3003,
@@ -99,7 +105,9 @@ export default class DataImport extends Service {
       },
       {
         EDID: 0,
-        floor: 3401,
+        floor: null,
+        floorType: null,
+        floorNumber: null,
         noOfHabitableRooms: 3,
         locationOfDwellingOnFloor: "Links",
         dwellingStatus: 3004,
@@ -110,6 +118,8 @@ export default class DataImport extends Service {
       {
         EDID: 0,
         floor: 3402,
+        floorType: 3401,
+        floorNumber: 2,
         noOfHabitableRooms: 2,
         locationOfDwellingOnFloor: "Rechts",
         dwellingStatus: 3007,


### PR DESCRIPTION
The floor type and number is concatenated and displayed under
floor in the import modal for the dwelling form.

![image](https://user-images.githubusercontent.com/32454507/137900272-e3049a22-1b79-4c22-8a73-aebaba909332.png)
