### PR TITLE
fix(login): remain on login page after failed login attempt

### DIFF
--- a/addon/services/auth-fetch.js
+++ b/addon/services/auth-fetch.js
@@ -17,6 +17,12 @@ export default class AuthFetchService extends Service {
     this.housingStatToken.perform();
   }
 
+  showLogin() {
+    this.showAuthModal = true;
+    this.token = undefined;
+    this.municipality = undefined;
+  }
+
   @task
   *housingStatToken(username, password, municipality) {
     if (
@@ -48,15 +54,17 @@ export default class AuthFetchService extends Service {
 
     if (!response.ok) {
       if (json["400"]?.source === "internal") {
-        this.showAuthModal = true;
+        this.showLogin();
       }
 
       if (json["401"]?.source === "external") {
         this.notification.danger(
           this.intl.t("ember-gwr.generalErrors.loginError")
         );
-        this.showAuthModal = true;
+        this.showLogin();
       }
+
+      return;
     }
 
     this.token = json.token;
@@ -76,9 +84,7 @@ export default class AuthFetchService extends Service {
     });
 
     if (response.ok || (!response.ok && response.status === 401)) {
-      this.showAuthModal = true;
-      this.token = undefined;
-      this.municipality = undefined;
+      this.showLogin();
     } else {
       this.notification.danger(
         this.intl.t("ember-gwr.generalErrors.logoutError")


### PR DESCRIPTION
As long as no valid credentials are provided by the user,
the user remains on the login page. Fixes a current bug that
redirects the user to the main page, even if invalid credentials
are provided (all subsequent requests fail due to not being
authenticated).

Resolves #190 