### PR TITLE
fix(import): add error handling for failed data imports

### DIFF
--- a/addon/components/model-form/header/actions.hbs
+++ b/addon/components/model-form/header/actions.hbs
@@ -78,12 +78,15 @@
           {{#if @modelHasImport}}
             <li>
               <LinkTo
-                @disabled={{@import}}
+                @disabled={{or @import this.importState.hasError}}
                 @query={{hash import=true}}
                 class="uk-button uk-text-left uk-highlight-hover
-                  {{if @import "uk-text-muted" "uk-text-secondary"}}
+                  {{if (or @import this.importState.hasError) "uk-text-muted" "uk-text-secondary"}}
                   uk-width-1-1 uk-background-default uk-padding-remove"
                 {{on "click" (fn (mut this.showImportModal) true)}}
+                uk-tooltip="title: {{if this.importState.hasError
+                    (t "ember-gwr.components.modelForm.importError")
+                  }}; container: {{this.config.modalContainer}}"
               >
                 {{t "ember-gwr.components.modelForm.importFromCaluma"}}
               </LinkTo>

--- a/addon/components/model-form/header/actions.js
+++ b/addon/components/model-form/header/actions.js
@@ -1,6 +1,9 @@
+import { inject as service } from "@ember/service";
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 
 export default class ModelFormHeaderActionsComponent extends Component {
   @tracked showImportModal = false;
+  @service importState;
+  @service config;
 }

--- a/addon/controllers/import.js
+++ b/addon/controllers/import.js
@@ -20,6 +20,7 @@ export default class ImportController extends Controller {
   ];
 
   @service dataImport;
+  @service importState;
 
   @tracked showImport = false;
   @tracked importIndex = undefined;
@@ -47,6 +48,7 @@ export default class ImportController extends Controller {
   resetImport() {
     this.showImport = false;
     this.importIndex = null;
+    this.importState.error = null;
   }
 
   @lastValue("fetchCalumaData") importData;
@@ -62,9 +64,15 @@ export default class ImportController extends Controller {
       "Must set `instanceId` on model.",
       this.model.instanceId !== null && this.model.instanceId !== undefined
     );
-    return yield this.dataImport[IMPORT_MAP[this.importModelName]](
-      this.model.instanceId,
-      ...args
-    );
+    try {
+      return yield this.dataImport[IMPORT_MAP[this.importModelName]](
+        this.model.instanceId,
+        ...args
+      );
+    } catch (error) {
+      console.error(error);
+      this.importState.error = error;
+      return error;
+    }
   }
 }

--- a/addon/services/import-state.js
+++ b/addon/services/import-state.js
@@ -1,0 +1,10 @@
+import Service from "@ember/service";
+import { tracked } from "@glimmer/tracking";
+
+export default class ImportStateService extends Service {
+  @tracked error;
+
+  get hasError() {
+    return Boolean(this.error);
+  }
+}

--- a/app/styles/ember-ebau-gwr.scss
+++ b/app/styles/ember-ebau-gwr.scss
@@ -114,7 +114,7 @@ $ember-ebau-gwr-required-color: $alert-danger-color !default;
   text-transform: unset;
 }
 
-.uk-button.disabled {
+:not(a).uk-button.disabled {
   @extend .uk-button-default;
 }
 

--- a/tests/unit/services/import-state-test.js
+++ b/tests/unit/services/import-state-test.js
@@ -1,0 +1,15 @@
+import engineResolverFor from "ember-engines/test-support/engine-resolver-for";
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+
+const modulePrefix = "ember-ebau-gwr";
+const resolver = engineResolverFor(modulePrefix);
+module("Unit | Service | import-state", function (hooks) {
+  setupTest(hooks, { resolver, integration: true });
+
+  // TODO: Replace this with your real tests.
+  test("it exists", function (assert) {
+    const service = this.owner.lookup("service:import-state");
+    assert.ok(service);
+  });
+});

--- a/translations/de.yaml
+++ b/translations/de.yaml
@@ -246,6 +246,7 @@ ember-gwr:
       realEstateHeading: Grundstücksidentifikation
       clientHeading: Auftraggeber
       validationError: Im Formular sind Eingabefehler vorhanden. Bitte korrigieren.
+      importError: Beim Importieren ist ein Fehler aufgetreten. Die Daten können zurzeit nicht übernommen werden.
 
       diff:
         existingData: Existierende Daten im GWR


### PR DESCRIPTION
Ensure that failed data imports are handled and don't
cause the entire application to malfunction. The import
button for the object is disabled with a tooltip in case
the import fails.