### PR TITLE
fix(street): enable country-coded locales for street language options

### DIFF
--- a/addon/controllers/building/edit/entrance/edit/link-street.js
+++ b/addon/controllers/building/edit/entrance/edit/link-street.js
@@ -3,7 +3,6 @@ import { action } from "@ember/object";
 import { inject as service } from "@ember/service";
 import { tracked } from "@glimmer/tracking";
 import { task, lastValue } from "ember-concurrency";
-import { languageOptions } from "ember-ebau-gwr/models/options";
 
 export default class BuildingEditEntranceLinkStreetController extends Controller {
   queryParams = ["locality", "PLZ4", "PLZ6"];
@@ -11,6 +10,7 @@ export default class BuildingEditEntranceLinkStreetController extends Controller
   @service street;
   @service buildingEntrance;
   @service building;
+  @service street;
   @service notification;
   @service intl;
   @service router;
@@ -56,7 +56,7 @@ export default class BuildingEditEntranceLinkStreetController extends Controller
   @task
   *search(query) {
     try {
-      query.language = languageOptions[this.intl.primaryLocale];
+      query.language = this.street.language;
       return yield this.street.search(query);
     } catch (error) {
       console.error(error);

--- a/addon/controllers/search-building.js
+++ b/addon/controllers/search-building.js
@@ -3,14 +3,12 @@ import { action } from "@ember/object";
 import { inject as service } from "@ember/service";
 import { tracked } from "@glimmer/tracking";
 import { task, dropTask, lastValue } from "ember-concurrency";
-import {
-  languageOptions,
-  periodOfConstructionOptions,
-} from "ember-ebau-gwr/models/options";
+import { periodOfConstructionOptions } from "ember-ebau-gwr/models/options";
 
 export default class SearchBuildingController extends Controller {
   @service building;
   @service constructionProject;
+  @service street;
   @service intl;
   @service notification;
   @service router;
@@ -23,7 +21,7 @@ export default class SearchBuildingController extends Controller {
   @lastValue("search") searchResults;
   @task *search(query) {
     try {
-      query.streetLang = languageOptions[this.intl.primaryLocale];
+      query.streetLang = this.street.language;
       query.municipality = this.building.municipality;
       return yield this.building.search(query);
     } catch (error) {

--- a/addon/routes/building/edit/entrance/new.js
+++ b/addon/routes/building/edit/entrance/new.js
@@ -1,11 +1,11 @@
 import { inject as service } from "@ember/service";
 import BuildingEntrance from "ember-ebau-gwr/models/building-entrance";
-import { languageOptions } from "ember-ebau-gwr/models/options";
 
 import IndexRoute from "./edit/index";
 
 export default class BuildingEditEntranceNewRoute extends IndexRoute {
   @service buildingEntrance;
+  @service street;
   @service intl;
 
   templateName = "building.edit.entrance.edit.index";
@@ -15,8 +15,7 @@ export default class BuildingEditEntranceNewRoute extends IndexRoute {
     const model = this.modelFor("building.edit");
 
     const buildingEntrance = new BuildingEntrance();
-    buildingEntrance.locality.name.language =
-      languageOptions[this.intl.primaryLocale];
+    buildingEntrance.locality.name.language = this.street.language;
     buildingEntrance.EGID = model.buildingId;
     return {
       ...model,

--- a/addon/services/street.js
+++ b/addon/services/street.js
@@ -1,3 +1,4 @@
+import { languageOptions } from "ember-ebau-gwr/models/options";
 import Street, { StreetList } from "ember-ebau-gwr/models/street";
 
 import GWRService from "./gwr";
@@ -14,6 +15,10 @@ export default class StreetService extends GWRService {
     const xml = await response.text();
     const street = new Street(xml, "streetWithoutStreetGeometryType");
     return this.cache(street);
+  }
+
+  get language() {
+    return languageOptions[this.intl.primaryLocale?.split("-")?.[0]];
   }
 
   async search(query = {}) {


### PR DESCRIPTION
Update the language option extraction for street names to allow
country codes in the locale (e.g. de-ch) provided through the host
application's intl service.