### PR TITLE
fix(intl): improve locality error messages

### DIFF
--- a/addon/services/building-entrance.js
+++ b/addon/services/building-entrance.js
@@ -71,7 +71,9 @@ export default class BuildingEntranceService extends GwrService {
       const errors = this.extractErrorsFromXML(
         xmlErrors,
         this.BuildingEntrance.LOCALITY_ERROR,
-        this.intl.t("ember-gwr.buildingEntrance.localityError")
+        this.intl.t("ember-gwr.buildingEntrance.localityError", {
+          htmlSafe: true,
+        })
       );
 
       console.error("GWR API: addBuildingEntrance failed");

--- a/addon/services/building.js
+++ b/addon/services/building.js
@@ -106,7 +106,9 @@ export default class BuildingService extends GwrService {
       const errors = this.extractErrorsFromXML(
         xmlErrors,
         this.BuildingEntrance.LOCALITY_ERROR,
-        this.intl.t("ember-gwr.building.buildingEntrance.localityError")
+        this.intl.t("ember-gwr.building.buildingEntrance.localityError", {
+          htmlSafe: true,
+        })
       );
 
       await this.constructionProject.removeWorkFromProject(EPROID, work.ARBID);

--- a/translations/building-entrance/de.yaml
+++ b/translations/building-entrance/de.yaml
@@ -8,7 +8,11 @@ ember-gwr:
     saveError: Beim Speichern des Eingangs ist ein Fehler aufgetreten.
     saveSuccess: Eingang erfolgreich gespeichert.
     loadingError: Beim Laden des Eingangs ist ein Fehler aufgetreten.
-    localityError: Beim Speichern der Ortschaft ist ein Fehler aufgetreten. Bitte überprüfen Sie Ihre Angaben.
+    localityError: |-
+      Beim Speichern des Eingangs ist ein Fehler aufgetreten. 
+      Bitte überprüfen Sie die <b>Kombination aus PLZ und Ortsname</b>, diese sollten exakt
+      mit den hinterlegten Daten auf der <a target="_blank" href="https://map.geo.admin.ch/?lang=de">eidgenössischen Kartenplattform</a>
+      übereinstimmen.
     street: Strasse
     coordinates: Koordinaten
     missingStreetInfo: Bitte verknüpfen Sie zuerst eine Strasse.

--- a/translations/building-entrance/fr.yaml
+++ b/translations/building-entrance/fr.yaml
@@ -8,7 +8,11 @@ ember-gwr:
     saveError: Une erreur s'est produite lors de la sauvegarde de l'entrée.
     saveSuccess: Entrée sauvegardée avec succès.
     loadingError: Une erreur s'est produite lors du chargement de l'entrée.
-    localityError: Une erreur est survenue lors de l'enregistrement de la localité. Veuillez vérifier vos données.
+    localityError: |-
+      Une erreur s'est produite lors de la sauvegarde de l'entrée.
+      Veuillez vérifier la <b>combinaison du NPA et 
+      de la désignation de la localité</b>, ceux-ci doivent correspondre exactement aux données 
+      enregistrées sur la <a target="_blank" href="https://map.geo.admin.ch/?lang=fr">plateforme cartographique fédérale</a>.
     street: Rue
     coordinates: Coordonnées
     missingStreetInfo: Veuillez d'abord lier une rue.

--- a/translations/building/de.yaml
+++ b/translations/building/de.yaml
@@ -278,4 +278,8 @@ ember-gwr:
     buildingEntrance:
       mainEntrance: Haupteingang
       info: Nach der Erstellung des Gebäudes können weitere Eingänge hinzugefügt werden und die Strassen der Eingänge bearbeitet werden.
-      localityError: Beim Speichern der Ortschaft des Haupteingangs ist ein Fehler aufgetreten. Bitte überprüfen Sie Ihre Angaben.
+      localityError: |-
+        Beim Speichern der Ortschaft des Haupteingangs ist ein Fehler aufgetreten. 
+        Bitte überprüfen Sie die <b>Kombination aus PLZ und Ortsname</b>, diese sollten exakt
+        mit den hinterlegten Daten auf der <a target="_blank" href="https://map.geo.admin.ch/?lang=de">eidgenössischen Kartenplattform</a>
+        übereinstimmen.

--- a/translations/building/fr.yaml
+++ b/translations/building/fr.yaml
@@ -278,4 +278,8 @@ ember-gwr:
     buildingEntrance:
       mainEntrance: Entrée principale
       info: Une fois le bâtiment créé, il est possible d'ajouter d'autres entrées et d'éditer les rues des entrées.
-      localityError: Une erreur est survenue lors de l'enregistrement de la localité de l'entrée principale. Veuillez vérifier vos données.
+      localityError: |-
+        Une erreur est survenue lors de l'enregistrement de la localité de 
+        l'entrée principale. Veuillez vérifier la <b>combinaison du NPA et 
+        de la désignation de la localité</b>, ceux-ci doivent correspondre exactement aux données 
+        enregistrées sur la <a target="_blank" href="https://map.geo.admin.ch/?lang=fr">plateforme cartographique fédérale</a>.


### PR DESCRIPTION
Improve the locality error messages that are triggered
when the GWR-API returns a "No link between locality and street"
error during building or entrance creation.