### PR TITLE
fix(project): use proper args for update function

### DIFF
--- a/addon/templates/project/form.hbs
+++ b/addon/templates/project/form.hbs
@@ -94,7 +94,7 @@
                     @convertValueTo="number"
                     @noPlaceholder={{true}}
                     @gwrEnumOptions={{this.kindOfWorkOptions}}
-                    @update={{fn this.updateWork model}}
+                    @on-update={{fn this.updateWork model}}
                     @translationBase="ember-gwr.buildingWork"
                     @noMargin={{true}}
                     @noLabel={{true}}


### PR DESCRIPTION
Previously `update` was used instead of `on-update`, causing the `updateModelField` to never be run, and causing visual issues on ember's rerendering action.